### PR TITLE
Switch to Managed ID token for cloud-to-cloud access

### DIFF
--- a/Data/NBARepo.cs
+++ b/Data/NBARepo.cs
@@ -15,6 +15,7 @@ public class NBARepo : BaseRepo, INBARepo
     {
         using (var connection = new SqlConnection(base.connectionString))
         {
+            await base.GenToken(connection);
             return await connection.GetAllAsync<NBARoster>();
         }
 

--- a/Data/NFLRepo.cs
+++ b/Data/NFLRepo.cs
@@ -17,6 +17,7 @@ public class NFLRepo : BaseRepo, INFLRepo
     {
         using (var connection = new SqlConnection(base.connectionString))
         {
+            await base.GenToken(connection);
             return await connection.GetAllAsync<NFLRoster>();
         }
     }

--- a/Data/NHLRepo.cs
+++ b/Data/NHLRepo.cs
@@ -17,6 +17,7 @@ public class NHLRepo : BaseRepo, INHLRepo
     {
         using (var connection = new SqlConnection(base.connectionString))
         {
+            await base.GenToken(connection);
             return await connection.GetAllAsync<NHLRoster>();
         }
 


### PR DESCRIPTION
Generate Managed ID token for azure cloud, keep Default token for desktop access to azure.
Default token didn't work for both scenarios.  Further research may simplify.