### PR TITLE
Allow sparse JSON updates in NBA Put API

### DIFF
--- a/Test/NBA.http
+++ b/Test/NBA.http
@@ -32,13 +32,7 @@ Content-Type: application/json
 
 {
   "playerID": 280,
-  "FirstName": "Minnie",
+  "FirstName": "Maxi",
   "LastName": "Mouse",
-  "Team": "76ers",
-  "Number": "66",
-  "Position": "C",
-  "Height": "6' 2\"",
-  "Weight": "233",
-  "DateOfBirth": "1991-04-26T00:00:00",
   "College": "Brown"
 }


### PR DESCRIPTION
Test a name update only, for example with no Team field present in the JSON since it isn't changing.

{
  "playerID": 280,
  "FirstName": "Maxi",
  "LastName": "Mouse"
}
