### PR TITLE
Included Copilot conversation about the Dapper sparse updates

### DIFF
--- a/Docs/Copilot/SparseUpdates.MD
+++ b/Docs/Copilot/SparseUpdates.MD
@@ -1,0 +1,55 @@
+## Logging the conversation with Copilot about SQL errors during sparse updates
+
+1. Why did I get an error on a sparse update JSON?  
+
+```csharp
+public async Task<bool> UpdateNBARoster(NBARoster roster, ILogger<NBARoster> logger) 
+{ 
+    try 
+    { 
+        using (var connection = new SqlConnection(base.connectionString)) { 
+            await base.GenToken(connection); 
+            await connection.UpdateAsync(roster); 
+            return true; 
+        }
+     } 
+    catch (Exception ex) 
+    { 
+        logger.LogError("Error updating NBA Roster: " + ex.Message); return false; 
+    } 
+}
+
+JSON: {"playerID": 281, "FirstName": "Minnie", "College": "Brown" }
+
+COPILOT response #1 (I didn't like the suggestion)
+The error you're encountering when performing a sparse update with JSON is likely due to the fact that the UpdateAsync method is trying to update the entire NBARoster object, but the JSON payload only includes a subset of the properties. This can cause issues if the NBARoster object has non-nullable properties that are not included in the JSON payload, or if the UpdateAsync method expects all properties to be present.
+
+Steps to Handle Sparse Updates
+Deserialize JSON to Partial Object: Deserialize the JSON payload to a partial object that only includes the properties present in the JSON.
+
+Retrieve Existing Record: Retrieve the existing record from the database.
+
+Apply Changes: Apply the changes from the partial object to the existing record.
+
+Update the Record: Update the record in the database.
+
+Example Implementation
+Here's how you can modify the UpdateNBARoster method to handle sparse updates:
+
+Define a Partial Update DTO: Create a DTO (Data Transfer Object) that includes only the properties that can be updated.
+
+(didn't like the implication of partial DTOs, potentially infinite)
+
+----------------------------------------------------------------------
+
+2. The missing field was Team. Could I more simply spin through the dom by reflection and update all fields that are not null? Allow empty string to "blank out" a value (not applicable here anyway) and assume no intentially updates are attempting to use null?
+
+COPILOT Response #2 (I liked this approach)
+Yes, you can use reflection to iterate through the properties of the NBARoster object and update only those that are not null. This approach allows you to dynamically handle sparse updates without manually checking each property. Here's how you can implement this:
+
+Step 1: Modify the UpdateNBARoster Method
+Retrieve the Existing Record: Retrieve the existing record from the database.
+Use Reflection to Update Properties: Use reflection to iterate through the properties of the NBARoster object and update only those that are not null.
+Update the Record: Update the record in the database.
+Example Implementation
+Here's how you can modify the UpdateNBARoster method to use reflection for updating properties


### PR DESCRIPTION
Copilot had some approaches I didn't go for and in the end I liked their suggestion of using reflection for the sparse updates, no matter what fields are or are not included, don't update based on any null, versus partial DTO class(es).

Open to suggestion how to capture these Copilot suggestions for posterity. Better format them, etc.