### PR TITLE
Add NFL API endpoint to fetch one or more players

### DIFF
--- a/Data/INFLRepo.cs
+++ b/Data/INFLRepo.cs
@@ -7,8 +7,7 @@ public interface INFLRepo
 {
     #region NFL
 
-    Task<IEnumerable<NFLRoster>> GetAllNFLRoster();
-    Task<IEnumerable<NFLRosterDto>> GetNFLRoster(ILogger<NFLRepo> logger);
+    Task<IEnumerable<NFLRosterDto>?> GetNFLRoster(ILogger<NFLRoster> logger, int? playerId);
 
     #endregion
 }

--- a/Endpoints/endpoints.nfl.cs
+++ b/Endpoints/endpoints.nfl.cs
@@ -11,12 +11,19 @@ public static class NflEndpoints
     /// <param name="routes">The endpoint route builder.</param>
     public static void MapNflEndpoints(this IEndpointRouteBuilder routes)
     {
-
         var NFL = routes.MapGroup("api/nfl");
-
-        NFL.MapGet("roster", async (INFLRepo repo, ILogger<NFLRepo> logger) =>
+        
+        NFL.MapGet("roster", async (ILogger<NFLRoster> logger, int? playerId, INFLRepo repo) =>
         {
-            return Results.Ok(await repo.GetNFLRoster(logger));
+            var results = await repo.GetNFLRoster(logger, playerId);
+            if (results != null)
+            {
+                return Results.Ok(results);
+            }
+            else
+            {
+                return Results.Problem("Error fetching NFL Roster, ask your admin to check the logs.");
+            }
         });
     }
 }


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Implement the first phase of adding CRUD support to the NFL API: support fetching a the entire list of players (roster) or a single player by ID

## Dependencies
- None

Implements # (issue) Part of GitHub Issue #31 

## Type of change

Please check relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local testing with Swagger on the developer machine.  Followed by post-deployment validation on Azure

- [ ] Swagger test of single and list of NHL roster players

## Checklist:

- [x] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules