### PR TITLE
GitHub Action @actions/upload-artifact@v2 is deprecated.  Updating to…

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -59,7 +59,7 @@ jobs:
         run: dotnet publish agility-sports-api.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: .net-app
           path: ${{env.DOTNET_ROOT}}/myapp


### PR DESCRIPTION
… @v4

<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Github action failed due to deprecated @actions/upload-artifact@v2, upgrading to recommended @v4.

## Dependencies
- AgilitySports_API dotnet build CI/CD

Fixes GitHub Action failure

## Type of change

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Commit changes and trigger new CI/CD GitHub Action for the API.

## Checklist:

- [ ] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules