### PR TITLE
NFL Roster CRUD endpoints and dapper functionality

### DIFF
--- a/Data/INFLRepo.cs
+++ b/Data/INFLRepo.cs
@@ -1,6 +1,5 @@
 using AgilitySportsAPI.Models;
 using AgilitySportsAPI.Dtos;
-using Microsoft.AspNetCore.Mvc;
 
 namespace AgilitySportsAPI.Data;
 public interface INFLRepo
@@ -8,6 +7,9 @@ public interface INFLRepo
     #region NFL
 
     Task<IEnumerable<NFLRosterDto>?> GetNFLRoster(ILogger<NFLRoster> logger, int? playerId);
+    Task<NFLRoster?> Create(NFLRoster player, ILogger<NFLRoster> logger);
+    Task<bool> Update(NFLRoster player, ILogger<NFLRoster> logger);
+    Task<bool> Delete(int playerId, ILogger<NFLRoster> logger);
 
     #endregion
 }

--- a/Data/NFLRepo.cs
+++ b/Data/NFLRepo.cs
@@ -48,5 +48,60 @@ public class NFLRepo : BaseRepo, INFLRepo
         }
     }
 
+    public async Task<NFLRoster?> Create(NFLRoster player, ILogger<NFLRoster> logger)
+    {
+        logger.LogInformation("Creating NFL Roster");
+        try
+        {
+            using (var connection = new SqlConnection(base.connectionString))
+            {
+                await base.GenToken(connection);
+                await connection.InsertAsync(player);
+                return player;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("Error creating NFL Roster: " + ex.Message);
+            return null;
+        }
+    }
+
+    public async Task<bool> Update(NFLRoster player, ILogger<NFLRoster> logger)
+    {
+        logger.LogInformation("Updating NFL Roster");
+        try
+        {
+            using (var connection = new SqlConnection(base.connectionString))
+            {
+                await base.GenToken(connection);
+                return await connection.UpdateAsync(player);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("Error updating NFL Roster: " + ex.Message);
+            return false;
+        }
+    }
+
+    public async Task<bool> Delete(int playerId, ILogger<NFLRoster> logger)
+    {
+        logger.LogInformation("Deleting NFL Roster");
+        try
+        {
+            using (var connection = new SqlConnection(base.connectionString))
+            {
+                await base.GenToken(connection);
+                return await connection.DeleteAsync(new NFLRoster { PlayerId = playerId });
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("Error deleting NFL Roster: " + ex.Message);
+            return false;
+        }
+    }
+
     #endregion
 }

--- a/Dtos/NFLRosterDto.cs
+++ b/Dtos/NFLRosterDto.cs
@@ -2,6 +2,7 @@ namespace AgilitySportsAPI.Dtos;
 
 public class NFLRosterDto
 {
+    public int playerID { get; set; }
     public string team { get; set; } = null!;
     public string name { get; set; } = null!;
     public string position { get; set; } = null!;

--- a/Endpoints/endpoints.nfl.cs
+++ b/Endpoints/endpoints.nfl.cs
@@ -13,6 +13,7 @@ public static class NflEndpoints
     {
         var NFL = routes.MapGroup("api/nfl");
         
+        // Read
         NFL.MapGet("roster", async (ILogger<NFLRoster> logger, int? playerId, INFLRepo repo) =>
         {
             var results = await repo.GetNFLRoster(logger, playerId);
@@ -23,6 +24,51 @@ public static class NflEndpoints
             else
             {
                 return Results.Problem("Error fetching NFL Roster, ask your admin to check the logs.");
+            }
+        });
+
+        // Create
+        NFL.MapPost("roster", async (ILogger<NFLRoster> logger, INFLRepo repo, NFLRoster roster) =>
+        {
+            NFLRoster? newPlayer = await repo.Create(roster, logger);
+
+            if (newPlayer != null)
+            {
+                return Results.Ok("Added to NFL Roster.");
+            }
+            else
+            {
+                return Results.Problem("Error adding to NFL Roster, check the logs.");
+            }
+        });
+
+        // Update
+        NFL.MapPut("roster", async (ILogger<NFLRoster> logger, INFLRepo repo, NFLRoster roster) =>
+        {
+            bool ret = await repo.Update(roster, logger);
+
+            if (ret == true)
+            {
+                return Results.Ok("Updated NFL Roster.");
+            }
+            else
+            {
+                return Results.Problem("Error updating the NFL Roster, check the logs.");
+            }
+        });
+
+        // Delete
+        NFL.MapDelete("roster", async (ILogger<NFLRoster> logger, INFLRepo repo, int playerId) =>
+        {
+            bool ret = await repo.Delete(playerId, logger);
+
+            if (ret == true)
+            {
+                return Results.Ok("Deleted from NFL Roster.");
+            }
+            else
+            {
+                return Results.Problem("Error deleting from NFL Roster, check the logs.");
             }
         });
     }

--- a/Models/NFLRoster.cs
+++ b/Models/NFLRoster.cs
@@ -6,7 +6,7 @@ namespace AgilitySportsAPI.Models;
 public record NFLRoster
 {
     [Key]
-    public int? PlayerId { get; set; }
+    public int PlayerId { get; set; }
     public string? Name { get; set; }
     public string? FirstName { get; set; }
     public string? LastName { get; set; }

--- a/Test/NFL.http
+++ b/Test/NFL.http
@@ -2,3 +2,67 @@
 
 ### get all roster
 get {{url}}nfl/roster
+
+### get player by PlayerID
+get {{url}}nfl/roster/?playerID=24904
+
+### create new player
+post {{url}}nfl/roster
+Content-Type: application/json
+
+{
+    "PlayerId": 0,
+    "Name": "John Doe",
+    "FirstName": "John",
+    "LastName": "Doe",
+    "Team": "NYG",
+    "Position": "QB",
+    "FantasyPosition": "QB",
+    "PositionCategory": "OFF",
+    "Height": "6'2\"",
+    "Weight": 220,
+    "Number": 12,
+    "CurrentStatus": "Healthy",
+    "CurrentStatusColor": "green",
+    "BirthDateShortString": "1995-05-15T00:00:00",
+    "Age": "29",
+    "AgeExact": 29.75,
+    "College": "Example University",
+    "CollegeDraftRound": "1",
+    "CollegeDraftPick": "10",
+    "ExperienceDigit": "5",
+    "PlayerUrlString": "http://example.com/player/johndoe",
+    "TeamName": "Example Team",
+    "TeamUrlString": "http://example.com/team/exampleteam",
+    "PhotoUrl": "http://example.com/player/johndoe/photo.jpg",
+    "PreferredHostedHeadshotUrl": "http://example.com/player/johndoe/headshot.jpg",
+    "LowResPreferredHostedHeadshotUrl": "http://example.com/player/johndoe/headshot_lowres.jpg",
+    "IsAvailableToPlay": true,
+    "Status": "Healthy",
+    "InjuryStatus": "None",
+    "InjuryBodyPart": "None",
+    "ShortName": "J. Doe",
+    "TeamDetails": "Example Team Details",
+    "CSName": "John Doe"
+}
+
+### update player by PlayerID
+put {{url}}nfl/roster/?playerID=3
+Content-Type: application/json
+
+{
+    "PlayerId": 24905,
+    "FirstName": "New First Name",
+    "LastName": "New Last Name",
+    "Name": "Dummy Name",
+    "Team": "New Team",
+    "Position": "QB",
+    "FantasyPosition": "QB",
+    "PositionCategory": "OFF",
+    "Height": "6'1\"",
+    "Weight": 222,
+    "Number": 13
+}
+
+### delete player by PlayerID
+delete {{url}}nfl/roster/?playerID=24905


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Implement support for Create, Update, Delete of NFL Roster players.  Add new REST API endpoints, and the dapper plumbing to support them.

## Dependencies
- None, no SQL database changes were required

Implements: NFL CRUD - API changes
[#31](https://github.com/smagara/AgilitySports_api/issues/31)

## Type of change: Enhancement

Please check relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] RestClient testing against local database
- [x] Swagger endpoint testing against Azure SQL database after deployment

## Checklist:

- [x] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (See NFL.http)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules