### PR TITLE
trap empty catch blocks in the CI/CD pipeline

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -39,6 +39,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check for empty C# catch blocks
+        run: |
+          if grep -Przon 'catch\s*\([^\)]*\)\s*\{\s*\}' . --include=*.cs; then
+            echo "ERROR: Empty catch block(s) found."
+            exit 1
+          fi
+
+      - name: Check for unlogged errors in C# catch blocks
+        run: |
+          # Find catch blocks that do not contain LogError, throw, or rethrow
+          if grep -Pozrn --include=*.cs 'catch\s*\([^\)]*\)\s*\{([^{}]*?(\n|.)*?)(?<!throw;)(?<!LogError;)\s*\}' . | grep -v 'catch\s*(.*)\s*{\s*}' | grep -v 'throw;' | grep -v 'LogError;'; then
+            echo "WARNING: Unlogged error found in catch block(s)."
+            exit 1
+          fi
+
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v2
         with:

--- a/Endpoints/endpoints.staticdata.cs
+++ b/Endpoints/endpoints.staticdata.cs
@@ -11,18 +11,25 @@ public static class StaticDataEndpoints
     /// <param name="routes">The endpoint route builder.</param>
     public static void MapStaticDataEndpoints(this IEndpointRouteBuilder routes)
     {
-        var staticData = routes.MapGroup("api/staticdata");
-        staticData.MapGet("positions", async (ILogger<PositionCodes> logger, IStaticData repoPosition, string sport) =>
+        try
         {
-            var results = await repoPosition.GetPositionCodes(logger, sport);
-            if (results != null)
+            var staticData = routes.MapGroup("api/staticdata");
+            staticData.MapGet("positions", async (ILogger<PositionCodes> logger, IStaticData repoPosition, string sport) =>
             {
-                return Results.Ok(results);
-            }
-            else
-            {
-                return Results.Problem("Error fetching sport Positions for " + sport + ", ask your admin to check the logs.");
-            }
-        });
+                var results = await repoPosition.GetPositionCodes(logger, sport);
+                if (results != null)
+                {
+                    return Results.Ok(results);
+                }
+                else
+                {
+                    return Results.Problem("Error fetching sport Positions for " + sport + ", ask your admin to check the logs.");
+                }
+            });
+        }
+        catch
+        {
+            // this exception doesn't log or rethrow.  The GitHub pipeline should fail if this happens.
+        }
     }
 }


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Configure the GitHub Action CI/CD pipeline to fail the build if it detects empty catch blocks.  These can be especially harmful if they are deployed to production, where they can cause silent damage to business and financial processes that can be challenging to detect and repair.

## Dependencies
- GitHub Action CI/CD pipeline

Fixes or Implements # (issue) 
GitHub Action CI/CD pipeline to check for empty Catch blocks
[#38](https://github.com/smagara/AgilitySports_api/issues/38)

## Type of change  DevOps CI/CD pipeline

Please check relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Purposefully push code with a catch block that doesn't rethrow or at least log the error
- [ ] Correct the code, and repush to confirm no issues

## Checklist:

- [ ] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules