### PR TITLE
Add 'a' flag to the grep command to treat all files as text

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Check for empty C# catch blocks
         run: |
-          if grep -Przon 'catch(\s*\([^\)]*\))?\s*\{\s*\}' . --include=*.cs; then
+          if grep -Przona 'catch(\s*\([^\)]*\))?\s*\{\s*\}' . --include=*.cs; then
             echo "ERROR: Empty catch block(s) found."
             exit 1
           fi
@@ -49,7 +49,7 @@ jobs:
       - name: Check for unlogged errors in C# catch blocks
         run: |
           # Find catch blocks (with or without parentheses) that do not contain LogError, throw, or rethrow
-          if grep -Pozrn --include=*.cs 'catch(\s*\([^\)]*\))?\s*\{([^{}]*?(\n|.)*?)(?<!throw;)(?<!LogError;)\s*\}' . | grep -v 'catch\s*(.*)\s*{\s*}' | grep -v 'catch\s*{\s*}' | grep -v 'throw;' | grep -v 'LogError;'; then
+          if grep -Pozrna --include=*.cs 'catch(\s*\([^\)]*\))?\s*\{([^{}]*?(\n|.)*?)(?<!throw;)(?<!LogError;)\s*\}' . | grep -v 'catch\s*(.*)\s*{\s*}' | grep -v 'catch\s*{\s*}' | grep -v 'throw;' | grep -v 'LogError;'; then
             echo "WARNING: Unlogged error found in catch block(s)."
             exit 1
           fi


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Refinement of the previous for Issue https://github.com/smagara/AgilitySports_api/issues/38. Use 'a' flag with grep to force it to consider all files as text.

Fixes or Implements # (issue) #38

## Type of change: DevOps

