### PR TITLE
More refactoring so grep will read the whole c# block

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -47,13 +47,13 @@ jobs:
             exit 1
           fi
 
-          # Find catch blocks (with or without parentheses) that do not contain throw or LogError
-          grep -Pzrnoa --include=*.cs 'catch(\s*\([^\)]*\))?\s*\{([^{}]*?)\}' . | while IFS=: read -r file line match; do
-            if [[ "$match" != *throw* && "$match" != *LogError* ]]; then
+          # Use a unique delimiter to capture the whole match
+          grep -Pzrnoa --include=*.cs --output-delimiter='|||' 'catch(\s*\([^\)]*\))?\s*\{([^{}]*?)\}' . | while IFS='|||' read -r file line match; do
+            if [[ -n "$match" && "$match" != *throw* && "$match" != *LogError* ]]; then
               echo "WARNING: Unlogged error found in catch block(s):"
               echo "File: $file"
               echo "Code:"
-              echo "  $match"
+              echo "$match"
               exit 1
             fi
           done

--- a/Data/NFLRepo.cs
+++ b/Data/NFLRepo.cs
@@ -99,7 +99,7 @@ public class NFLRepo : BaseRepo, INFLRepo
         }
         catch (Exception ex)
         {
-            logger.LogError("Error deleting NFL Roster: " + ex.Message);
+            //logger.LogError("Error deleting NFL Roster: " + ex.Message);
             return false;
         }
     }


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

More refactoring from Copilot since the negative test failed.  NHL was untouched and should have passed.  I put the error back in NFL to start a new cycle.  

At this point, it's very complex regex logic and I'm in pure vibe mode.

For Item #38