### PR TITLE
Switching from regex/grep/awk to roslyn script solution from ChatGPT

### DIFF
--- a/.github/workflows/azure-webapps-dotnet-core.yml
+++ b/.github/workflows/azure-webapps-dotnet-core.yml
@@ -39,33 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for empty or unlogged C# catch blocks
-        run: |
-          # Find empty catch blocks (with or without parentheses)
-          if grep -Przona --include=*.cs 'catch(\s*\([^\)]*\))?\s*\{\s*\}' .; then
-            echo "ERROR: Empty catch block(s) found."
-            exit 1
-          fi
+      - name: Install dotnet-script
+        run: dotnet tool install -g dotnet-script
 
-          # Find catch blocks (with or without parentheses) that do not contain throw or LogError
-          grep -Pzrnoa --include=*.cs 'catch(\s*\([^\)]*\))?\s*\{([^{}]*?)\}' . | \
-          awk -F: '
-            {
-              file=$1; line=$2;
-              code="";
-              for(i=3;i<=NF;++i) {
-                code = code (i==3 ? "" : ":") $i
-              }
-              if (code !~ /throw/ && code !~ /LogError/) {
-                print "WARNING: Unlogged error found in catch block(s):";
-                print "File: " file;
-                print "Line: " line;
-                print "Code:";
-                print code;
-                exit 1
-              }
-            }
-          '
+      - name: Run Catch Block Analysis
+        run: dotnet-script scripts/CheckCatchBlocks.csx
 
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v2

--- a/Data/NFLRepo.cs
+++ b/Data/NFLRepo.cs
@@ -99,7 +99,7 @@ public class NFLRepo : BaseRepo, INFLRepo
         }
         catch (Exception ex)
         {
-            //logger.LogError("Error deleting NFL Roster: " + ex.Message);
+            logger.LogError("Error deleting NFL Roster: " + ex.Message);
             return false;
         }
     }

--- a/roslyn/CheckCatchBlocks.csx
+++ b/roslyn/CheckCatchBlocks.csx
@@ -1,0 +1,51 @@
+#r "nuget: Microsoft.CodeAnalysis.CSharp, 4.8.0"
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.IO;
+
+int violations = 0;
+string[] files = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.cs", SearchOption.AllDirectories);
+
+foreach (var file in files)
+{
+    var code = File.ReadAllText(file);
+    var tree = CSharpSyntaxTree.ParseText(code);
+    var root = tree.GetRoot();
+
+    var catchClauses = root.DescendantNodes().OfType<CatchClauseSyntax>();
+
+    foreach (var catchClause in catchClauses)
+    {
+        var block = catchClause.Block;
+
+        if (block == null || !block.Statements.Any())
+        {
+            Console.WriteLine($"❌ Empty catch block: {file}");
+            violations++;
+            continue;
+        }
+
+        bool hasLogError = block.Statements
+            .OfType<ExpressionStatementSyntax>()
+            .Any(stmt =>
+                stmt.ToString().Contains("LogError"));
+
+        if (!hasLogError)
+        {
+            Console.WriteLine($"❌ Catch block missing LogError: {file}");
+            violations++;
+        }
+    }
+}
+
+if (violations > 0)
+{
+    Console.WriteLine($"\nFound {violations} catch block violations.");
+    Environment.Exit(1);
+}
+else
+{
+    Console.WriteLine("✅ All catch blocks are valid.");
+}

--- a/roslyn/runchecks.bat
+++ b/roslyn/runchecks.bat
@@ -1,0 +1,1 @@
+ dotnet-script ./CheckCatchBlocks.csx


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

For Issue #38, ditching the regex/grep/awk text-based solution recommended by Copilot and going with the much more robust, understandable, and code-specific roslyn script approach suggested by ChatGPT.  There were too many tweaks for too many false negatives and positives.  Roslyn makes more sense.