### PR TITLE
Unit testing for Subitem #61 player exists for update

### DIFF
--- a/Test/NBA.http
+++ b/Test/NBA.http
@@ -45,3 +45,13 @@ Content-Type: application/json
   "playerID": 5,
   "Height": "6' 5\""
 }
+
+### Update NBA player that doesn't exist
+PUT {{url}}NBA/roster
+Content-Type: application/json
+
+{
+  "playerID": 9990211,
+  "FirstName": "Maxi",
+  "LastName": "Mouse"
+}

--- a/Test/NFL.http
+++ b/Test/NFL.http
@@ -65,3 +65,22 @@ Content-Type: application/json
 
 ### delete player by PlayerID
 delete {{url}}nfl/roster/?playerID=24905
+
+### update a player that doesn't exist
+put {{url}}nfl/roster
+Content-Type: application/json
+
+{
+    "PlayerId": 999902,
+    "FirstName": "New First Name",
+    "LastName": "New Last Name",
+    "Name": "Dummy Name",
+    "Team": "New Team",
+    "Position": "QB",
+    "FantasyPosition": "QB",
+    "PositionCategory": "OFF",
+    "Height": "6'1\"",
+    "Weight": 222,
+    "Number": 13,
+    "age": 33
+}

--- a/Test/NHL.http
+++ b/Test/NHL.http
@@ -44,3 +44,20 @@ Content-Type: application/json
   "birthPlace": "nowhere",
   "birthCountry": "noplace"
 }
+
+### Attempt update to a player that doesn't exist
+PUT http://localhost:1106/api/nhl/roster
+Content-Type: application/json
+
+{
+  "playerID": 999901,
+  "name": "JD Grier",
+  "team": "Bruins",
+  "number": "13",
+  "position": "LW",
+  "handed": "B",
+  "age": 33,
+  "drafted": 2011,
+  "birthPlace": "nowhere",
+  "birthCountry": "noplace"
+}


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Unit tests to check that a PlayerID for any sport exists before attempting the update and provide relevant feedback.
Add to the existing RESTClient .http files, some exercise for the player doesn't exist during update scenario

## Dependencies
- #59

Fixes or Implements # (issue) #61

## Type of change: Add unit tests

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] RESTClient unit testing for various sports.  Attempt updates to impossible PlayerIDs

