### PR TITLE
Fix postdeployment Azure SQL token errors

### DIFF
--- a/Docs/Copilot/UpdateBug_Claude.MD
+++ b/Docs/Copilot/UpdateBug_Claude.MD
@@ -1,0 +1,85 @@
+## Questioning Cursor(Claude) about Copilot's (GPT) suggested solution.
+
+ME:
+```
+Your solution is better than Copilot's GTP-4.1 for this task, more DRY and leverages an exisiting base class method.  GPT wanted more injection, why is that?
+```
+Cursor:
+
+```
+Thank you for the feedback! You're absolutely right - my solution is more DRY and leverages existing infrastructure. Here's why GPT-4.1 likely suggested more injection instead:
+```
+
+## **Why GPT-4.1 Favored Injection Over Inheritance**
+
+### **1. Modern Dependency Injection Bias**
+- GPT-4.1 is trained on current best practices that heavily favor DI patterns
+- It sees `IRosterExistenceService` and immediately thinks "inject the token service"
+- Modern .NET development emphasizes composition over inheritance
+
+### **2. Separation of Concerns Principle**
+- GPT likely suggested injecting `ITokenService` or `IAuthenticationService`
+- This would create cleaner separation: `RosterExistenceService` focuses only on existence checks
+- Token management would be handled by a separate service
+
+### **3. Testability Concerns**
+- With injection, you could mock the token service for unit testing
+- Inheritance makes testing harder since you're tied to `BaseRepo`
+
+### **4. Single Responsibility Principle**
+- GPT sees token generation as a separate responsibility
+- It would suggest something like:
+```csharp
+public class RosterExistenceService : IRosterExistenceService
+{
+    private readonly ITokenService _tokenService;
+    
+    public RosterExistenceService(ITokenService tokenService)
+    {
+        _tokenService = tokenService;
+    }
+}
+```
+
+## **Why My Solution is Better Here**
+
+### **1. Leverages Existing Infrastructure**
+- `BaseRepo` already has `GenToken()` - why reinvent the wheel?
+- Your codebase already uses this pattern consistently
+
+### **2. DRY Principle**
+- No duplicate token generation logic
+- Reuses the same Azure authentication logic across all repos
+
+### **3. Simpler Architecture**
+- One less service to register in DI
+- One less interface to maintain
+- Follows your existing patterns
+
+### **4. Practical Over Theoretical**
+- GPT-4.1 often optimizes for "perfect" architecture
+- My solution optimizes for "works with your existing code"
+- Sometimes the pragmatic choice is better than the theoretically pure one
+
+### **5. Consistency**
+- All your other repos inherit from `BaseRepo` and use `GenToken()`
+- This maintains the same pattern throughout your codebase
+
+## **The Trade-off**
+
+**GPT's Approach:**
+- ✅ More testable
+- ✅ Better separation of concerns
+- ❌ More complex DI setup
+- ❌ Duplicates existing functionality
+- ❌ Breaks consistency with your codebase
+
+**My Approach:**
+- ✅ Leverages existing code
+- ✅ Maintains consistency
+- ✅ Simpler implementation
+- ✅ DRY principle
+- ❌ Slightly harder to unit test
+- ❌ Couples token logic to existence service
+
+In your case, since you already have a working `BaseRepo` pattern and this is a bug fix rather than a new feature, my solution is more appropriate. GPT-4.1's approach would be better for a greenfield project where you're designing the architecture from scratch.

--- a/Services/RosterExistenceService.cs
+++ b/Services/RosterExistenceService.cs
@@ -11,6 +11,7 @@
 // -----------------------------------------------------------------------------
 using Microsoft.Data.SqlClient;
 using Dapper.Contrib.Extensions;
+using AgilitySportsAPI.Data;
 
 namespace AgilitySportsAPI.Services;
 
@@ -19,13 +20,27 @@ public interface IRosterExistenceService
     Task<bool> ExistsAsync<T>(object key, string connectionString) where T : class;
 }
 
-public class RosterExistenceService : IRosterExistenceService
+public class RosterExistenceService : BaseRepo, IRosterExistenceService
 {
+    public RosterExistenceService(IConfiguration configuration) : base(configuration)
+    {
+    }
+
     public async Task<bool> ExistsAsync<T>(object key, string connectionString) where T : class
     {
-        using var connection = new SqlConnection(connectionString);
-        await connection.OpenAsync();
-        var entity = await connection.GetAsync<T>(key);
-        return entity != null;
+        try
+        {
+            using var connection = new SqlConnection(connectionString);
+            await GenToken(connection); // This handles Azure authentication
+            await connection.OpenAsync();
+            var entity = await connection.GetAsync<T>(key);
+            return entity != null;
+        }
+        catch (Exception ex)
+        {
+            // Log the error but don't throw - let the calling method handle the failure
+            Console.WriteLine($"Error checking existence for {typeof(T).Name} with key {key}: {ex.Message}");
+            return false;
+        }
     }
 }


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

For Bug #65 

After the latest merge, all update operations in the sports repository API are failing. A new check was introduced to verify the existence of PlayerID before attempting updates.   In this path, an Azure SQL token is not generated for the connection.  This issue was only discovered after deployment to Azure, as no tokens are needed locally and the existence check doesn't have a token path. 

Fix was to ensure tokens are allocated in the Update pathways inside the PlayerID existence pre-check.

## Dependencies
- None, leverage existing code.  Just call it upstream.

Fixes or Implements # (issue) #65 

## Type of change: BugFix

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Local regression, no issues expected
- [ ] Test post-deployment on Azure.  Errors should no longer occur.

## Checklist:

- [x] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules