### PR TITLE
Fix GitHub CI/CD Build failure.  Ensure proper catch block handling

### DIFF
--- a/Services/RosterExistenceService.cs
+++ b/Services/RosterExistenceService.cs
@@ -22,8 +22,11 @@ public interface IRosterExistenceService
 
 public class RosterExistenceService : BaseRepo, IRosterExistenceService
 {
-    public RosterExistenceService(IConfiguration configuration) : base(configuration)
+    private readonly ILogger<RosterExistenceService> _logger;
+
+    public RosterExistenceService(IConfiguration configuration, ILogger<RosterExistenceService> logger) : base(configuration)
     {
+        _logger = logger;
     }
 
     public async Task<bool> ExistsAsync<T>(object key, string connectionString) where T : class
@@ -39,7 +42,7 @@ public class RosterExistenceService : BaseRepo, IRosterExistenceService
         catch (Exception ex)
         {
             // Log the error but don't throw - let the calling method handle the failure
-            Console.WriteLine($"Error checking existence for {typeof(T).Name} with key {key}: {ex.Message}");
+            _logger.LogError(ex, "Error checking existence for {EntityType} with key {Key}", typeof(T).Name, key);
             return false;
         }
     }


### PR DESCRIPTION
…ling

<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

GitHub Action CI/CD build failure.  Roslyn precheck fails because LogError() is not called.  Good catch!!
Fix is to add the required call to the catch().

```
❌ Catch block missing LogError: /home/runner/work/AgilitySports_api/AgilitySports_api/Services/RosterExistenceService.cs
```

## Dependencies
- None

Fixes or Implements # (issue) #65

## Type of change: DevOps

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
