### PR TITLE
Use same BaseRepo base class to calculate Upsert connectionstrings

### DIFF
--- a/Data/PlayersRepo.cs
+++ b/Data/PlayersRepo.cs
@@ -5,17 +5,10 @@ using System.Configuration;
 
 namespace AgilitySportsAPI.Data;
 
-public class PlayersRepo : IPlayersRepo
+public class PlayersRepo : BaseRepo, IPlayersRepo
 {
-    private readonly string _connectionString;
-
-    public PlayersRepo(IConfiguration configuration)
+    public PlayersRepo(IConfiguration configuration) : base(configuration)
     {
-        _connectionString = configuration.GetConnectionString("DockerConnectionV2") ?? "";
-        if (_connectionString == "")
-        {
-            throw new ConfigurationErrorsException("ConnectionStrings:DockerConnectionV2 must be set for V2 player APIs.");
-        }
     }
 
     public async Task<IEnumerable<PlayerSummaryDto>?> GetPlayers(
@@ -54,7 +47,8 @@ public class PlayersRepo : IPlayersRepo
                         and (@search is null or p.firstName like @searchLike or p.lastName like @searchLike)
                     order by p.lastName, p.firstName, p.playerID;";
 
-            using var connection = new SqlConnection(_connectionString);
+            using var connection = new SqlConnection(base.connectionString);
+            await base.GenToken(connection);
 
             var trimmedSearch = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
             var trimmedSportCode = string.IsNullOrWhiteSpace(sportCode) ? null : sportCode.Trim();
@@ -103,7 +97,8 @@ public class PlayersRepo : IPlayersRepo
                         and pc.positionCode = p.positionCode
                     where p.playerID = @playerId;";
 
-            using var connection = new SqlConnection(_connectionString);
+            using var connection = new SqlConnection(base.connectionString);
+            await base.GenToken(connection);
             return await connection.QuerySingleOrDefaultAsync<PlayerSummaryDto>(sql, new { playerId });
         }
         catch (Exception ex)
@@ -152,7 +147,8 @@ public class PlayersRepo : IPlayersRepo
                         and nhl.sportCode = p.sportCode
                     where p.playerID = @playerId;";
 
-            using var connection = new SqlConnection(_connectionString);
+            using var connection = new SqlConnection(base.connectionString);
+            await base.GenToken(connection);
             return await connection.QuerySingleOrDefaultAsync<PlayerStatsDto>(sql, new { playerId });
         }
         catch (Exception ex)

--- a/Services/PlayersV2WriteService.cs
+++ b/Services/PlayersV2WriteService.cs
@@ -1,8 +1,6 @@
 using AgilitySportsAPI.Data;
 using AgilitySportsAPI.Dtos;
-using Dapper;
 using Microsoft.Data.SqlClient;
-using System.Configuration;
 
 namespace AgilitySportsAPI.Services;
 
@@ -27,33 +25,34 @@ public interface IPlayersV2WriteService
     Task<bool> UpsertPlayerStats(ILogger logger, int playerId, PlayerStatsUpsertDto stats);
 }
 
-public class PlayersV2WriteService : IPlayersV2WriteService
+public class PlayersV2WriteService : BaseRepo, IPlayersV2WriteService
 {
-    private readonly string _connectionString;
     private readonly IPlayersRepo _playersRepo;
 
-    public PlayersV2WriteService(IConfiguration configuration, IPlayersRepo playersRepo)
+    public PlayersV2WriteService(IConfiguration configuration, IPlayersRepo playersRepo) : base(configuration)
     {
         _playersRepo = playersRepo;
-        _connectionString = configuration.GetConnectionString("DockerConnectionV2") ?? "";
-        if (_connectionString == "")
-        {
-            throw new ConfigurationErrorsException("ConnectionStrings:DockerConnectionV2 must be set for V2 player APIs.");
-        }
+    }
+
+    private async Task<SqlConnection> OpenConnectionAsync()
+    {
+        var connection = new SqlConnection(base.connectionString);
+        await base.GenToken(connection);
+        await connection.OpenAsync();
+        return connection;
     }
 
     public async Task<int?> CreatePlayer(ILogger logger, PlayerUpsertDto player)
     {
-        using var connection = new SqlConnection(_connectionString);
-        await connection.OpenAsync();
+        using var connection = await OpenConnectionAsync();
 
         using var transaction = connection.BeginTransaction();
         try
         {
-            var teamCode = await ResolveTeamCodeAsync(connection, transaction, player.SportCode, player.TeamCode);
+            var teamCode = NormalizeTeamCode(player.TeamCode);
             if (string.IsNullOrWhiteSpace(teamCode) || teamCode.Length != 3)
             {
-                logger.LogError("Invalid team value '{Team}' for sport '{SportCode}'. Unable to resolve 3-letter team code.", player.TeamCode, player.SportCode);
+                logger.LogError("Invalid team code '{Team}' for sport '{SportCode}'. Expected 3-letter TeamCode.", player.TeamCode, player.SportCode);
                 transaction.Rollback();
                 return null;
             }
@@ -74,16 +73,15 @@ public class PlayersV2WriteService : IPlayersV2WriteService
 
     public async Task<int?> CreatePlayerWithStats(ILogger logger, PlayerUpsertDto player, PlayerStatsUpsertDto stats)
     {
-        using var connection = new SqlConnection(_connectionString);
-        await connection.OpenAsync();
+        using var connection = await OpenConnectionAsync();
 
         using var transaction = connection.BeginTransaction();
         try
         {
-            var teamCode = await ResolveTeamCodeAsync(connection, transaction, player.SportCode, player.TeamCode);
+            var teamCode = NormalizeTeamCode(player.TeamCode);
             if (string.IsNullOrWhiteSpace(teamCode) || teamCode.Length != 3)
             {
-                logger.LogError("Invalid team value '{Team}' for sport '{SportCode}'. Unable to resolve 3-letter team code.", player.TeamCode, player.SportCode);
+                logger.LogError("Invalid team code '{Team}' for sport '{SportCode}'. Expected 3-letter TeamCode.", player.TeamCode, player.SportCode);
                 transaction.Rollback();
                 return null;
             }
@@ -123,16 +121,15 @@ public class PlayersV2WriteService : IPlayersV2WriteService
 
     public async Task<PlayerWriteOutcome> UpdatePlayerDetailed(ILogger logger, int playerId, PlayerUpsertDto player)
     {
-        using var connection = new SqlConnection(_connectionString);
-        await connection.OpenAsync();
+        using var connection = await OpenConnectionAsync();
 
         using var transaction = connection.BeginTransaction();
         try
         {
-            var teamCode = await ResolveTeamCodeAsync(connection, transaction, player.SportCode, player.TeamCode);
+            var teamCode = NormalizeTeamCode(player.TeamCode);
             if (string.IsNullOrWhiteSpace(teamCode) || teamCode.Length != 3)
             {
-                logger.LogError("Invalid team value '{Team}' for sport '{SportCode}'. Unable to resolve 3-letter team code.", player.TeamCode, player.SportCode);
+                logger.LogError("Invalid team code '{Team}' for sport '{SportCode}'. Expected 3-letter TeamCode.", player.TeamCode, player.SportCode);
                 transaction.Rollback();
                 return PlayerWriteOutcome.InvalidTeam;
             }
@@ -165,16 +162,15 @@ public class PlayersV2WriteService : IPlayersV2WriteService
 
     public async Task<PlayerWriteOutcome> UpdatePlayerWithStatsDetailed(ILogger logger, int playerId, PlayerUpsertDto player, PlayerStatsUpsertDto stats)
     {
-        using var connection = new SqlConnection(_connectionString);
-        await connection.OpenAsync();
+        using var connection = await OpenConnectionAsync();
 
         using var transaction = connection.BeginTransaction();
         try
         {
-            var teamCode = await ResolveTeamCodeAsync(connection, transaction, player.SportCode, player.TeamCode);
+            var teamCode = NormalizeTeamCode(player.TeamCode);
             if (string.IsNullOrWhiteSpace(teamCode) || teamCode.Length != 3)
             {
-                logger.LogError("Invalid team value '{Team}' for sport '{SportCode}'. Unable to resolve 3-letter team code.", player.TeamCode, player.SportCode);
+                logger.LogError("Invalid team code '{Team}' for sport '{SportCode}'. Expected 3-letter TeamCode.", player.TeamCode, player.SportCode);
                 transaction.Rollback();
                 return PlayerWriteOutcome.InvalidTeam;
             }
@@ -208,8 +204,7 @@ public class PlayersV2WriteService : IPlayersV2WriteService
 
     public async Task<bool> DeletePlayer(ILogger logger, int playerId)
     {
-        using var connection = new SqlConnection(_connectionString);
-        await connection.OpenAsync();
+        using var connection = await OpenConnectionAsync();
 
         using var transaction = connection.BeginTransaction();
         try
@@ -242,8 +237,7 @@ public class PlayersV2WriteService : IPlayersV2WriteService
 
     public async Task<bool> UpsertPlayerStats(ILogger logger, int playerId, PlayerStatsUpsertDto stats)
     {
-        using var connection = new SqlConnection(_connectionString);
-        await connection.OpenAsync();
+        using var connection = await OpenConnectionAsync();
 
         using var transaction = connection.BeginTransaction();
         try
@@ -273,35 +267,13 @@ public class PlayersV2WriteService : IPlayersV2WriteService
         }
     }
 
-    private static async Task<string?> ResolveTeamCodeAsync(
-        SqlConnection connection,
-        SqlTransaction transaction,
-        string? sportCode,
-        string? teamValue)
+    private static string? NormalizeTeamCode(string? teamCode)
     {
-        var normalizedSport = string.IsNullOrWhiteSpace(sportCode) ? null : sportCode.Trim().ToUpperInvariant();
-        var normalizedTeam = string.IsNullOrWhiteSpace(teamValue) ? null : teamValue.Trim();
-
-        if (string.IsNullOrWhiteSpace(normalizedSport) || string.IsNullOrWhiteSpace(normalizedTeam))
+        if (string.IsNullOrWhiteSpace(teamCode))
         {
             return null;
         }
 
-        var sql = @"
-                select top 1 teamCode
-                from core.Teams
-                where sportCode = @sportCode
-                  and (
-                        upper(teamCode) = upper(@team)
-                     or upper(teamShortName) = upper(@team)
-                     or upper(teamName) = upper(@team)
-                  );";
-
-        var resolved = await connection.QuerySingleOrDefaultAsync<string>(
-            sql,
-            new { sportCode = normalizedSport, team = normalizedTeam },
-            transaction);
-
-        return resolved?.Trim().ToUpperInvariant();
+        return teamCode.Trim().ToUpperInvariant();
     }
 }


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Fix a bug found on Azure where the code was using the dev Docker connection string instead of the BaseRepo base class logic to connect to the relevant configured setting. Fallout from the deployment.

TODO: analyze this pathway as it gets called repeatedly.

## Dependencies
- None

Fixes or Implements # (issue) #76 

## Type of change:

- [x] Bug fix
- [ ] Enhancement
- [ ] DevOps
- [ ] Other:

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Local Swagger endpoint testing
- [x] Local Web testing

## Checklist:

- [x] I have opened my PR against the staging branch, NOT against main
- [x] I have personally reviewed any AI-provided suggestions
- [x] I have requested a Copilot review of this PR
- [ ] My code follows the style guidelines of this project, formatting and lint-ing
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
