### PR TITLE
Add fifa API crud

### DIFF
--- a/Data/FIFRepo.cs
+++ b/Data/FIFRepo.cs
@@ -1,0 +1,88 @@
+using AgilitySportsAPI.Models;
+using Microsoft.Data.SqlClient;
+using AgilitySportsAPI.Dtos;
+using Dapper;
+
+namespace AgilitySportsAPI.Data;
+
+public class FIFRepo : BaseRepo, IFIFRepo
+{
+    public FIFRepo(IConfiguration configuration) : base(configuration)
+    {
+    }
+
+    public async Task<IEnumerable<FIFRosterDto>?> GetFIFRoster(ILogger<FIFRoster> logger, int? playerId)
+    {
+        try
+        {
+            logger.LogInformation("Fetching FIF Roster");
+
+            var sql = @"
+            select p.playerID as PlayerId
+                ,p.firstName as FirstName
+                ,p.lastName as LastName
+                ,p.teamCode as TeamCode
+                ,p.teamCode as Team
+                ,t.teamShortName as TeamName
+                ,t.league as League
+                ,coalesce(pc.positionDesc, p.positionCode) as Position
+                ,convert(varchar(10), p.number) as Number
+                ,convert(varchar(10), p.heightInches) as Height
+                ,convert(varchar(10), p.weight) as Weight
+                ,p.dateOfBirth as DateOfBirth
+                ,p.college as College
+                ,p.birthCityState as BirthCityState
+                ,p.birthCountry as BirthCountry
+                ,p.draftYear as DraftYear
+                ,p.seasonYear as SeasonYear
+                ,fif.totalGoals as TotalGoals
+                ,fif.assists as Assists
+                ,fif.saves as Saves
+            from core.Players p
+            left join core.Teams t
+                on t.sportCode = p.sportCode
+                and t.teamCode = p.teamCode
+            left join reference.PositionCodes pc
+                on pc.sportCode = p.sportCode
+                and pc.positionCode = p.positionCode
+            left join stats.FIFPlayerStats fif
+                on fif.playerID = p.playerID
+                and fif.sportCode = p.sportCode
+            where p.sportCode = 'FIF'
+                and (@playerId is null or p.playerID = @playerId)
+            order by
+                p.playerID, p.lastName, p.firstName";
+
+            using (var connection = new SqlConnection(base.connectionString))
+            {
+                await base.GenToken(connection);
+                return await connection.QueryAsync<FIFRosterDto>(sql, new { playerId });
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error fetching FIF roster.");
+            return null;
+        }
+    }
+
+    public async Task<FIFRoster?> CreateFIFRoster(FIFRoster roster, ILogger<FIFRoster> logger)
+    {
+        logger.LogError("Legacy FIF roster write endpoints are not supported on DB V2. Use /api/v2/players.");
+        return null;
+    }
+
+    public async Task<bool> UpdateFIFRoster(FIFRoster roster, ILogger<FIFRoster> logger)
+    {
+        logger.LogError("Legacy FIF roster write endpoints are not supported on DB V2. Use /api/v2/players.");
+        await Task.CompletedTask;
+        return false;
+    }
+
+    public async Task<bool> DeleteFIFRoster(int playerId, ILogger<FIFRoster> logger)
+    {
+        logger.LogError("Legacy FIF roster write endpoints are not supported on DB V2. Use /api/v2/players.");
+        await Task.CompletedTask;
+        return false;
+    }
+}

--- a/Data/IFIFRepo.cs
+++ b/Data/IFIFRepo.cs
@@ -1,0 +1,12 @@
+using AgilitySportsAPI.Models;
+using AgilitySportsAPI.Dtos;
+
+namespace AgilitySportsAPI.Data;
+
+public interface IFIFRepo
+{
+    Task<IEnumerable<FIFRosterDto>?> GetFIFRoster(ILogger<FIFRoster> logger, int? playerId);
+    Task<FIFRoster?> CreateFIFRoster(FIFRoster roster, ILogger<FIFRoster> logger);
+    Task<bool> UpdateFIFRoster(FIFRoster roster, ILogger<FIFRoster> logger);
+    Task<bool> DeleteFIFRoster(int playerId, ILogger<FIFRoster> logger);
+}

--- a/Data/PlayersRepo.cs
+++ b/Data/PlayersRepo.cs
@@ -132,6 +132,9 @@ public class PlayersRepo : BaseRepo, IPlayersRepo
                         ,nhl.penaltyMinutes as PenaltyMinutes
                         ,nhl.points as Points
                         ,nhl.savePct as SavePct
+                        ,fif.totalGoals as TotalGoals
+                        ,fif.assists as Assists
+                        ,fif.saves as Saves
                     from core.Players p
                     left join stats.MLBPlayerStats mlb
                         on mlb.playerID = p.playerID
@@ -145,6 +148,9 @@ public class PlayersRepo : BaseRepo, IPlayersRepo
                     left join stats.NHLPlayerStats nhl
                         on nhl.playerID = p.playerID
                         and nhl.sportCode = p.sportCode
+                    left join stats.FIFPlayerStats fif
+                        on fif.playerID = p.playerID
+                        and fif.sportCode = p.sportCode
                     where p.playerID = @playerId;";
 
             using var connection = new SqlConnection(base.connectionString);
@@ -362,6 +368,20 @@ public class PlayersRepo : BaseRepo, IPlayersRepo
                         insert into stats.NHLPlayerStats(playerID, sportCode, handed, goals, penaltyMinutes, points, savePct)
                         values(@playerId, @sportCode, @handed, @goals, @penaltyMinutes, @points, @savePct);
                     end;",
+            "FIF" => @"
+                    if exists (select 1 from stats.FIFPlayerStats where playerID = @playerId and sportCode = @sportCode)
+                    begin
+                        update stats.FIFPlayerStats
+                        set totalGoals = @totalGoals
+                            ,assists = @assists
+                            ,saves = @saves
+                        where playerID = @playerId and sportCode = @sportCode;
+                    end
+                    else
+                    begin
+                        insert into stats.FIFPlayerStats(playerID, sportCode, totalGoals, assists, saves)
+                        values(@playerId, @sportCode, @totalGoals, @assists, @saves);
+                    end;",
             _ => throw new ArgumentException($"Unsupported sportCode '{sportCode}' for stats upsert.")
         };
 
@@ -385,7 +405,10 @@ public class PlayersRepo : BaseRepo, IPlayersRepo
                 goals = stats.Goals,
                 penaltyMinutes = stats.PenaltyMinutes,
                 points = stats.Points,
-                savePct = stats.SavePct
+                savePct = stats.SavePct,
+                totalGoals = stats.TotalGoals,
+                assists = stats.Assists,
+                saves = stats.Saves
             },
             transaction);
 
@@ -406,6 +429,7 @@ public class PlayersRepo : BaseRepo, IPlayersRepo
             "NBA" => @"delete from stats.NBAPlayerStats where playerID = @playerId and sportCode = @sportCode;",
             "NFL" => @"delete from stats.NFLPlayerStats where playerID = @playerId and sportCode = @sportCode;",
             "NHL" => @"delete from stats.NHLPlayerStats where playerID = @playerId and sportCode = @sportCode;",
+            "FIF" => @"delete from stats.FIFPlayerStats where playerID = @playerId and sportCode = @sportCode;",
             _ => throw new ArgumentException($"Unsupported sportCode '{sportCode}' for stats delete.")
         };
 

--- a/Docs/FIF-API.md
+++ b/Docs/FIF-API.md
@@ -31,6 +31,8 @@ This document covers the FIFA/FIF roster CRUD endpoints exposed by AgilitySports
 - `teamCode` is the required internal key for team resolution.
 - Typical payload fields:
   - `playerId`, `teamCode`, `firstName`, `lastName`, `position`, `number`, `height`, `weight`, `dateOfBirth`, `birthCityState`, `birthCountry`, `college`, `draftYear`, `seasonYear`.
+  - FIF stats fields (optional): `totalGoals`, `assists`, `saves`.
+- FIF stats values must be whole numbers greater than or equal to `0`.
 
 ## REST Client Tests
 

--- a/Docs/FIF-API.md
+++ b/Docs/FIF-API.md
@@ -1,0 +1,39 @@
+# FIF API (V2)
+
+This document covers the FIFA/FIF roster CRUD endpoints exposed by AgilitySports API V2.
+
+## Base Route
+
+`/api/v2/fif`
+
+## Endpoints
+
+- `GET /api/v2/fif/roster`
+  - Returns all FIF players.
+  - Optional query string: `playerId`.
+  - Example: `/api/v2/fif/roster?playerId=105228`
+
+- `POST /api/v2/fif/roster`
+  - Creates a FIF player via the V2 player write service.
+  - Requires `teamCode`.
+
+- `PUT /api/v2/fif/roster`
+  - Updates a FIF player via the V2 player write service.
+  - Requires `playerId` and `teamCode`.
+
+- `DELETE /api/v2/fif/roster?playerId={id}`
+  - Deletes a FIF player by `playerId`.
+
+## Request Notes
+
+- Writes are validated for XSS and structured field rules before persistence.
+- Input values are sanitized before write operations.
+- `teamCode` is the required internal key for team resolution.
+- Typical payload fields:
+  - `playerId`, `teamCode`, `firstName`, `lastName`, `position`, `number`, `height`, `weight`, `dateOfBirth`, `birthCityState`, `birthCountry`, `college`, `draftYear`, `seasonYear`.
+
+## REST Client Tests
+
+Runnable examples are available in:
+
+- [../Test/FIF.http](../Test/FIF.http)

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,5 +1,9 @@
 # Philly,NET - August 16, 2023
 
+## Current API Additions
+
+- FIF V2 API documentation: [FIF-API.md](FIF-API.md)
+
 ## [Meetup site](https://www.meetup.com/philly-net/events/295026043/) for this event
 
 ***

--- a/Dtos/FIFRosterDto.cs
+++ b/Dtos/FIFRosterDto.cs
@@ -1,0 +1,25 @@
+namespace AgilitySportsAPI.Dtos;
+
+public class FIFRosterDto
+{
+    public int PlayerId { get; set; }
+    public string? TeamCode { get; set; }
+    public string? Team { get; set; }
+    public string? TeamName { get; set; }
+    public string League { get; set; } = null!;
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public string? Number { get; set; }
+    public string? Position { get; set; }
+    public string? Height { get; set; }
+    public string? Weight { get; set; }
+    public DateTime? DateOfBirth { get; set; }
+    public string? College { get; set; }
+    public string? BirthCityState { get; set; }
+    public string? BirthCountry { get; set; }
+    public short? DraftYear { get; set; }
+    public short? SeasonYear { get; set; }
+    public int? TotalGoals { get; set; }
+    public int? Assists { get; set; }
+    public int? Saves { get; set; }
+}

--- a/Dtos/PlayerStatsDto.cs
+++ b/Dtos/PlayerStatsDto.cs
@@ -27,4 +27,9 @@ public class PlayerStatsDto
     public int? PenaltyMinutes { get; set; }
     public int? Points { get; set; }
     public decimal? SavePct { get; set; }
+
+    // FIF (FIFA World Cup)
+    public int? TotalGoals { get; set; }
+    public int? Assists { get; set; }
+    public int? Saves { get; set; }
 }

--- a/Dtos/PlayerStatsUpsertDto.cs
+++ b/Dtos/PlayerStatsUpsertDto.cs
@@ -24,4 +24,9 @@ public class PlayerStatsUpsertDto
     public int? PenaltyMinutes { get; set; }
     public int? Points { get; set; }
     public decimal? SavePct { get; set; }
+
+    // FIF (FIFA World Cup)
+    public int? TotalGoals { get; set; }
+    public int? Assists { get; set; }
+    public int? Saves { get; set; }
 }

--- a/Endpoints/endpoints.fif.cs
+++ b/Endpoints/endpoints.fif.cs
@@ -1,0 +1,257 @@
+// This file contains the endpoints for FIFA World Cup (FIF) roster CRUD.
+
+using AgilitySportsAPI.Data;
+using AgilitySportsAPI.Dtos;
+using AgilitySportsAPI.Models;
+using AgilitySportsAPI.Services;
+
+public static class FifEndpoints
+{
+    /// <summary>
+    /// Maps the FIF-related endpoints such as CRUD operations on the FIFA World Cup roster.
+    /// </summary>
+    public static void MapFifEndpoints(this IEndpointRouteBuilder routes)
+    {
+        void MapFifRoutes(RouteGroupBuilder fif)
+        {
+            fif.MapGet("roster", async (ILogger<FIFRoster> logger, int? playerId, IFIFRepo repo) =>
+            {
+                var results = await repo.GetFIFRoster(logger, playerId);
+                if (results != null)
+                {
+                    return Results.Ok(results);
+                }
+
+                return Results.Problem("Error fetching FIF Roster, ask your admin to check the logs.");
+            });
+
+            fif.MapPost("roster", async (
+                ILogger<FIFRoster> logger,
+                IPlayersV2WriteService writeService,
+                IXssValidationService xssValidator,
+                IInputSanitizationService sanitizer,
+                IInputValidationService validator,
+                FIFRoster roster) =>
+            {
+                var (isValid, violations) = xssValidator.ValidateTextFields(roster, logger);
+                if (!isValid)
+                {
+                    logger.LogWarning("XSS attempt blocked in FIF roster creation. Violations: {Violations}", string.Join(", ", violations));
+                    return Results.BadRequest(new
+                    {
+                        Error = "XSS attempt detected",
+                        Message = "The request contains potentially malicious content and has been blocked for security reasons.",
+                        Details = violations
+                    });
+                }
+
+                var (isValidStructured, validationErrors) = validator.ValidateModel(roster, logger);
+                if (!isValidStructured)
+                {
+                    logger.LogWarning("Validation errors in FIF roster creation. Errors: {Errors}", string.Join(", ", validationErrors));
+                    return Results.BadRequest(new
+                    {
+                        Error = "Validation failed",
+                        Message = "The request contains invalid data for structured fields.",
+                        Details = validationErrors
+                    });
+                }
+
+                var (statsValid, statsErrors) = ValidateFifStats(roster);
+                if (!statsValid)
+                {
+                    return Results.BadRequest(new
+                    {
+                        Error = "Validation failed",
+                        Message = "The request contains invalid FIF stats.",
+                        Details = statsErrors
+                    });
+                }
+
+                var sanitizedRoster = sanitizer.SanitizeModel(roster, logger);
+                var player = MapToPlayerUpsert(sanitizedRoster);
+
+                if (string.IsNullOrWhiteSpace(player.TeamCode))
+                {
+                    return Results.BadRequest(new
+                    {
+                        Error = "Validation failed",
+                        Message = "Team code is required."
+                    });
+                }
+
+                var hasStats = HasStats(sanitizedRoster);
+                var createdId = hasStats
+                    ? await writeService.CreatePlayerWithStats(logger, player, MapToStatsUpsert(sanitizedRoster))
+                    : await writeService.CreatePlayer(logger, player);
+
+                if (createdId != null)
+                {
+                    return Results.Ok("Added to FIF Roster.");
+                }
+
+                return Results.Problem("Error adding to FIF Roster, check the logs.");
+            });
+
+            fif.MapPut("roster", async (
+                ILogger<FIFRoster> logger,
+                IPlayersV2WriteService writeService,
+                IXssValidationService xssValidator,
+                IInputSanitizationService sanitizer,
+                IInputValidationService validator,
+                FIFRoster roster) =>
+            {
+                var (isValid, violations) = xssValidator.ValidateTextFields(roster, logger);
+                if (!isValid)
+                {
+                    logger.LogWarning("XSS attempt blocked in FIF roster update. Violations: {Violations}", string.Join(", ", violations));
+                    return Results.BadRequest(new
+                    {
+                        Error = "XSS attempt detected",
+                        Message = "The request contains potentially malicious content and has been blocked for security reasons.",
+                        Details = violations
+                    });
+                }
+
+                var (isValidStructured, validationErrors) = validator.ValidateModel(roster, logger);
+                if (!isValidStructured)
+                {
+                    logger.LogWarning("Validation errors in FIF roster update. Errors: {Errors}", string.Join(", ", validationErrors));
+                    return Results.BadRequest(new
+                    {
+                        Error = "Validation failed",
+                        Message = "The request contains invalid data for structured fields.",
+                        Details = validationErrors
+                    });
+                }
+
+                var (statsValid, statsErrors) = ValidateFifStats(roster);
+                if (!statsValid)
+                {
+                    return Results.BadRequest(new
+                    {
+                        Error = "Validation failed",
+                        Message = "The request contains invalid FIF stats.",
+                        Details = statsErrors
+                    });
+                }
+
+                var sanitizedRoster = sanitizer.SanitizeModel(roster, logger);
+                var player = MapToPlayerUpsert(sanitizedRoster);
+
+                if (string.IsNullOrWhiteSpace(player.TeamCode))
+                {
+                    return Results.BadRequest(new
+                    {
+                        Error = "Validation failed",
+                        Message = "Team code is required."
+                    });
+                }
+
+                var hasStats = HasStats(sanitizedRoster);
+                var updateOutcome = hasStats
+                    ? await writeService.UpdatePlayerWithStatsDetailed(logger, sanitizedRoster.PlayerId, player, MapToStatsUpsert(sanitizedRoster))
+                    : await writeService.UpdatePlayerDetailed(logger, sanitizedRoster.PlayerId, player);
+
+                if (updateOutcome == PlayerWriteOutcome.Success)
+                {
+                    return Results.Ok("Updated FIF Roster.");
+                }
+
+                if (updateOutcome == PlayerWriteOutcome.NotFound)
+                {
+                    return Results.NotFound("FIF player was not found or update failed.");
+                }
+
+                if (updateOutcome == PlayerWriteOutcome.InvalidTeam)
+                {
+                    return Results.BadRequest(new
+                    {
+                        Error = "Validation failed",
+                        Message = "Team code could not be resolved for FIF."
+                    });
+                }
+
+                if (updateOutcome == PlayerWriteOutcome.StatsFailed)
+                {
+                    return Results.Problem("FIF player update failed while writing stats. Check logs for details.");
+                }
+
+                return Results.Problem("Error updating FIF Roster, check the logs.");
+            });
+
+            fif.MapDelete("roster", async (ILogger<FIFRoster> logger, IPlayersV2WriteService writeService, int playerId) =>
+            {
+                var deleted = await writeService.DeletePlayer(logger, playerId);
+
+                if (deleted)
+                {
+                    return Results.Ok("Deleted from FIF Roster.");
+                }
+
+                return Results.NotFound("FIF player was not found or delete failed.");
+            });
+        }
+
+        MapFifRoutes(routes.MapGroup("api/v2/fif"));
+    }
+
+    private static PlayerUpsertDto MapToPlayerUpsert(FIFRoster roster) => new()
+    {
+        SportCode = "FIF",
+        TeamCode = roster.TeamCode?.Trim() ?? roster.Team?.Trim() ?? string.Empty,
+        PositionCode = roster.Position?.Trim(),
+        FirstName = roster.FirstName,
+        LastName = roster.LastName,
+        DateOfBirth = roster.DateOfBirth,
+        Height = roster.Height,
+        Weight = ParseNullableInt(roster.Weight),
+        Number = ParseNullableInt(roster.Number),
+        College = roster.College,
+        BirthCityState = roster.BirthCityState,
+        BirthCountry = roster.BirthCountry,
+        DraftYear = roster.DraftYear,
+        SeasonYear = roster.SeasonYear
+    };
+
+    private static PlayerStatsUpsertDto MapToStatsUpsert(FIFRoster roster) => new()
+    {
+        TotalGoals = roster.TotalGoals,
+        Assists = roster.Assists,
+        Saves = roster.Saves
+    };
+
+    private static bool HasStats(FIFRoster roster) =>
+        roster.TotalGoals.HasValue || roster.Assists.HasValue || roster.Saves.HasValue;
+
+    private static (bool IsValid, List<string> Errors) ValidateFifStats(FIFRoster roster)
+    {
+        var errors = new List<string>();
+        if (roster.TotalGoals.HasValue && roster.TotalGoals.Value < 0)
+        {
+            errors.Add("TotalGoals must be greater than or equal to 0.");
+        }
+
+        if (roster.Assists.HasValue && roster.Assists.Value < 0)
+        {
+            errors.Add("Assists must be greater than or equal to 0.");
+        }
+
+        if (roster.Saves.HasValue && roster.Saves.Value < 0)
+        {
+            errors.Add("Saves must be greater than or equal to 0.");
+        }
+
+        return (errors.Count == 0, errors);
+    }
+
+    private static int? ParseNullableInt(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return int.TryParse(value.Trim(), out var parsed) ? parsed : null;
+    }
+}

--- a/Models/FIFRoster.cs
+++ b/Models/FIFRoster.cs
@@ -1,0 +1,29 @@
+using Dapper.Contrib.Extensions;
+
+namespace AgilitySportsAPI.Models;
+
+[Table("core.Players")]
+public record FIFRoster
+{
+    [Key]
+    public int PlayerId { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public string? TeamCode { get; set; }
+    public string? Team { get; set; }
+    public string? League { get; set; }
+    public string? Position { get; set; }
+    public string? Number { get; set; }
+    public string? Height { get; set; }
+    public string? Weight { get; set; }
+    public DateTime? DateOfBirth { get; set; }
+    public string? College { get; set; }
+    public string? TeamName { get; set; }
+    public string? BirthCityState { get; set; }
+    public string? BirthCountry { get; set; }
+    public short? DraftYear { get; set; }
+    public short? SeasonYear { get; set; }
+    public int? TotalGoals { get; set; }
+    public int? Assists { get; set; }
+    public int? Saves { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -24,6 +24,7 @@ ILoggingBuilder logB = builder.Logging.AddLog4Net(
 builder.Services.AddScoped<INFLRepo, NFLRepo>();
 builder.Services.AddScoped<INHLRepo, NHLRepo>();
 builder.Services.AddScoped<INBARepo, NBARepo>();
+builder.Services.AddScoped<IFIFRepo, FIFRepo>();
 builder.Services.AddTransient<IColorWheel, ColorWheel>();  // for MLB Colorwheel DI
 builder.Services.AddScoped<IMLBRepo, MLBRepo>();
 builder.Services.AddScoped<IPlayersRepo, PlayersRepo>();
@@ -61,6 +62,7 @@ app.MapNbaEndpoints();
 app.MapNflEndpoints();
 app.MapMlbEndpoints();
 app.MapNhlEndpoints();
+app.MapFifEndpoints();
 app.MapStaticDataEndpoints();
 app.MapPlayersV2Endpoints();
 // Add database health endpoint

--- a/Services/InputValidationService.cs
+++ b/Services/InputValidationService.cs
@@ -188,7 +188,9 @@ public class InputValidationService : IInputValidationService
             // NHL
             "C", "D", "F", "G", "LW", "RW",
             // MLB
-            "1B", "2B", "3B", "C", "CF", "DH", "LF", "P", "RF", "RP", "SP", "SS"
+            "1B", "2B", "3B", "C", "CF", "DH", "LF", "P", "RF", "RP", "SP", "SS",
+            // FIF (FIFA World Cup)
+            "G", "D", "M", "F", "UNK"
         };
 
         var cleanInput = input.Trim().ToUpper();
@@ -215,6 +217,7 @@ public class InputValidationService : IInputValidationService
             "NFL" => new[] { "C", "CB", "DB", "DE", "DL", "DT", "FB", "G", "ILB", "K", "LB", "LS", "NT", "OL", "OLB", "OT", "P", "QB", "RB", "S", "TE", "WR" },
             "NHL" => new[] { "C", "D", "F", "G", "LW", "RW" },
             "MLB" => new[] { "1B", "2B", "3B", "C", "CF", "DH", "LF", "P", "RF", "RP", "SP", "SS" },
+            "FIF" => new[] { "G", "D", "M", "F", "UNK" },
 
             _ => new string[0] // Unknown sport
         };

--- a/Test/FIF.http
+++ b/Test/FIF.http
@@ -25,8 +25,9 @@ Content-Type: application/json
     "college": null,
     "draftYear": 2026,
     "seasonYear": 2026,
-    "totalGoals" : 9,
-    "assists" : 13
+    "totalGoals": 9,
+    "assists": 13,
+    "saves": 2
 }
 
 ### update FIF player by playerId
@@ -47,7 +48,10 @@ Content-Type: application/json
     "birthCountry": "United States",
     "college": null,
     "draftYear": 2026,
-    "seasonYear": 2026
+    "seasonYear": 2026,
+    "totalGoals": 10,
+    "assists": 14,
+    "saves": 3
 }
 
 ### delete FIF player by playerId

--- a/Test/FIF.http
+++ b/Test/FIF.http
@@ -1,0 +1,65 @@
+@url = http://localhost:1106/api/v2/
+
+### list FIF players
+GET {{url}}fif/roster
+
+### get FIF player by playerId
+GET {{url}}fif/roster?playerId=105228
+
+### create new FIF player
+POST {{url}}fif/roster
+Content-Type: application/json
+
+{
+    "playerId": 0,
+    "teamCode": "USA",
+    "firstName": "Test",
+    "lastName": "Forward",
+    "position": "F",
+    "number": "9",
+    "height": "72",
+    "weight": "175",
+    "dateOfBirth": "1999-01-15T00:00:00",
+    "birthCityState": "Dallas, TX",
+    "birthCountry": "United States",
+    "college": null,
+    "draftYear": 2026,
+    "seasonYear": 2026,
+    "totalGoals" : 9,
+    "assists" : 13
+}
+
+### update FIF player by playerId
+PUT {{url}}fif/roster
+Content-Type: application/json
+
+{
+    "playerId": 9001001,
+    "teamCode": "USA",
+    "firstName": "Test",
+    "lastName": "Forward-Updated",
+    "position": "M",
+    "number": "10",
+    "height": "72",
+    "weight": "178",
+    "dateOfBirth": "1999-01-15T00:00:00",
+    "birthCityState": "Dallas, TX",
+    "birthCountry": "United States",
+    "college": null,
+    "draftYear": 2026,
+    "seasonYear": 2026
+}
+
+### delete FIF player by playerId
+DELETE {{url}}fif/roster?playerId=9000002
+
+### validation check (missing teamCode)
+POST {{url}}fif/roster
+Content-Type: application/json
+
+{
+    "playerId": 0,
+    "firstName": "Bad",
+    "lastName": "Payload",
+    "position": "F"
+}

--- a/readme.md
+++ b/readme.md
@@ -86,3 +86,8 @@ Dev Note (July 2026):
 
 - Overall API specification (purpose, architecture, setup, endpoint catalog, request/response conventions, usage workflow): [Docs/AgilitySports_API_Overall_Specification.docx](Docs/AgilitySports_API_Overall_Specification.docx)
 - Player/stats contract specification (cross-sport stat field mapping and persistence behavior): [Docs/AgilitySports_API_PlayerStats_Spec.docx](Docs/AgilitySports_API_PlayerStats_Spec.docx)
+- FIF API quick reference (routes, payload expectations, and test links): [Docs/FIF-API.md](Docs/FIF-API.md)
+
+## REST Client Tests
+
+- FIF CRUD REST Client script: [Test/FIF.http](Test/FIF.http)


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Add FIFA World Cup Soccer support for 2026 to the data model and API crud.

## Dependencies
- FIFA database upgrade is successful

Fixes or Implements # (issue) #

## Type of change:

- [ ] Bug fix
- [x] Enhancement
- [ ] DevOps
- [ ] Other:

Please check relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Swagger unit tests
- [x] RESTClient unit tests

## Checklist:

- [x] I have opened my PR against the staging branch, NOT against main
- [x] I have personally reviewed any AI-provided suggestions
- [x] I have requested a Copilot review of this PR
- [ ] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
